### PR TITLE
Fixed minor bugs.

### DIFF
--- a/jsk_rviz_plugins/src/overlay_menu_display.cpp
+++ b/jsk_rviz_plugins/src/overlay_menu_display.cpp
@@ -63,9 +63,11 @@ namespace jsk_rviz_plugins
     left_property_ = new rviz::IntProperty("left", 128,
                                            "left of the image window",
                                            this, SLOT(updateLeft()));
+    left_property_->setMin(0);
     top_property_ = new rviz::IntProperty("top", 128,
                                           "top of the image window",
                                           this, SLOT(updateTop()));
+    top_property_->setMin(0);
     keep_centered_property_ = new rviz::BoolProperty("keep centered", true,
                                                      "enable automatic center adjustment",
                                                      this, SLOT(updateKeepCentered()));
@@ -82,6 +84,9 @@ namespace jsk_rviz_plugins
 
   void OverlayMenuDisplay::onInitialize()
   {
+    updateKeepCentered();
+    updateLeft();
+    updateTop();
     require_update_texture_ = false;
     animation_state_ = CLOSED;
   }
@@ -433,6 +438,11 @@ namespace jsk_rviz_plugins
 
   void OverlayMenuDisplay::updateKeepCentered()
   {
+    if (keep_centered_ &&
+        !keep_centered_property_->getBool()) {
+      updateLeft();
+      updateTop();
+    }
     boost::mutex::scoped_lock lock(mutex_);
     keep_centered_ = keep_centered_property_->getBool();
   }


### PR DESCRIPTION
This PR fixed some minor bugs, including the one mentioned under the discussion in  #762
> When keep centered box is initially checked, user can still reposition the menu window.
This unexpected behavior is fixed after uncheck and then re-check the checkbox.